### PR TITLE
Image util

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(fname):
 
 setup(
     name='ecs-cluster',
-    version='1.0.5',
+    version='1.0.6',
     author='Silvercar',
     author_email="info@silvercar.com",
     url='https://github.com/silvercar/ecs-cluster',

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -192,6 +192,11 @@ class ECSClient(object):
 
         return new_task_definition_arn
 
+    def get_task_images(self, task_definition_arn):
+        response = self.ecs_client.describe_task_definition(
+            taskDefinition=task_definition_arn)
+        return [ { 'container': x['name'] , 'image': x['image'] } for x in response['taskDefinition']['containerDefinitions']]
+
     def clone_task(self, task_definition_arn, container_name, image_name):
         """ Clones a task and sets its image attribute. Returns the new
             task definition arn if successful, otherwise None
@@ -409,3 +414,4 @@ class ECSClient(object):
         response = self.ec2_client.describe_instances(InstanceIds=ids)
         details = response['Reservations'][0]['Instances'][0]
         return details
+

--- a/src/ecs_cluster/main.py
+++ b/src/ecs_cluster/main.py
@@ -111,6 +111,16 @@ def update_taskdef(ctx, cluster, service, service_arn, taskdef_text):
         click.echo('Success')
     click.echo('')
 
+@click.command('get-images')
+@click.option("--cluster", required=True)
+@click.option("--service", required=True)
+@click.option("--container", required=False)
+@click.pass_context
+def get_image(ctx, cluster, service, container):
+    ecs_client = ECSClient(timeout=ctx.obj['timeout'])
+    task_arn = ecs_client.get_task_definition_arn(cluster, service)
+    response = ecs_client.get_task_images(task_arn)
+    print(json.dumps(response))
 
 @click.command('ssh-service')
 @click.option("--cluster", required=True)
@@ -131,8 +141,8 @@ def ssh_service(ctx, cluster, service, service_arn, task_arn, rails, user, keydi
         click.echo('No matching service found for cluster %s' %
                    cluster, err=True)
         sys.exit(1)
-
     service_cmd = 'rails console' if rails else '/bin/bash'
+
 
     if chamber_env:
         service_cmd = 'chamber exec {} -- {}'.format(chamber_env, service_cmd)
@@ -156,3 +166,4 @@ cli.add_command(update_image)
 cli.add_command(update_taskdef)
 cli.add_command(ssh_service)
 cli.add_command(docker_stats)
+cli.add_command(get_image)

--- a/src/ecs_cluster/main.py
+++ b/src/ecs_cluster/main.py
@@ -116,7 +116,7 @@ def update_taskdef(ctx, cluster, service, service_arn, taskdef_text):
 @click.option("--service", required=True)
 @click.option("--container", required=False)
 @click.pass_context
-def get_image(ctx, cluster, service, container):
+def get_images(ctx, cluster, service, container):
     ecs_client = ECSClient(timeout=ctx.obj['timeout'])
     task_arn = ecs_client.get_task_definition_arn(cluster, service)
     response = ecs_client.get_task_images(task_arn)
@@ -166,4 +166,4 @@ cli.add_command(update_image)
 cli.add_command(update_taskdef)
 cli.add_command(ssh_service)
 cli.add_command(docker_stats)
-cli.add_command(get_image)
+cli.add_command(get_images)


### PR DESCRIPTION
Adds a new option get-images which returns a json blob of active images and containers per service (this was needed for some promotion logic) -- also bumps the version.

