### PR TITLE
Dont deregister latest task definition on update image

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Note the `--restart` flag.
 1. Branch off of master, so make sure you're on master first: `git checkout master`
 2. Create your feature branch: `git checkout -b my-new-feature`
 3. Test your changes:
+    (From the root of the repository, run: )
     ```bash
-    $ virtualenv venv --python=python3
+    $ virtualenv venv --python=python3.6
     $ . venv/bin/activate
     $ pip install --editable .
     $ ecs-cluster

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note the `--restart` flag.
 
 ## Contributing
 
-1. Branch off of develop, so make sure you're on develop first: `git checkout develop`
+1. Branch off of master, so make sure you're on master first: `git checkout master`
 2. Create your feature branch: `git checkout -b my-new-feature`
 3. Test your changes:
     ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ polling
 requests
 paramiko
 pylint
+urllib3==1.24

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(fname):
 
 setup(
     name='ecs-cluster',
-    version='1.2.0',
+    version='1.2.1',
     author='Silvercar',
     author_email="info@silvercar.com",
     url='https://github.com/silvercar/ecs-cluster',

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -106,8 +106,9 @@ class ECSClient:
             one that's currently active.
         """
         old_taskdef_arn = self.get_task_definition_arn(cluster_name, service_arn)
+        latest_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn)
         if latest:
-            old_taskdef_arn = self.get_latest_task_definition_arn(cluster_name, service_arn)
+            old_taskdef_arn = latest_task_definition_arn
 
         if old_taskdef_arn is None:
             _print_error(
@@ -123,8 +124,9 @@ class ECSClient:
                 "Unable to clone the task definition " + old_taskdef_arn)
             return False
 
-        # Deregister the old task definition
-        self.deregister_task_definition(old_taskdef_arn)
+        # Deregister the old task definition ONLY IF it is not the latest revision
+        if old_taskdef_arn != latest_task_definition_arn:
+            self.deregister_task_definition(old_taskdef_arn)
 
         service = self.update_service(cluster_name, service_arn, new_taskdef_arn)
         if not service:


### PR DESCRIPTION
Modified the update_image function to only deregister the old task definition if it is not the latest revision.