### PR TITLE
Resolve bug where the incorrect service would be returned.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(fname):
 
 setup(
     name='ecs-cluster',
-    version='1.2.1',
+    version='1.2.2',
     author='Silvercar',
     author_email="info@silvercar.com",
     url='https://github.com/silvercar/ecs-cluster',

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -147,17 +147,6 @@ class ECSClient:
             return None
         return response['serviceArns']
 
-    def get_default_service_arn(self, cluster_name):
-        """ Returns the ARN of the first service found for the cluster
-        """
-        try:
-            response = self.ecs_client.list_services(cluster=cluster_name)
-        except ClientError:
-            return None
-        if response is None or not response['serviceArns']:
-            return None
-        return response['serviceArns'][0]
-
     def get_service(self, cluster_name, service_arn):
         """ Returns the service object matching the service ARN
         """

--- a/src/ecs_cluster/main.py
+++ b/src/ecs_cluster/main.py
@@ -64,7 +64,7 @@ def list_services(ctx, cluster):
 @click.option("--latest", is_flag=True, default=False,
               help="Update the latest task definition, even if it's not the one currently in use")
 @click.pass_context
-def update_image(ctx, cluster, service, service_arn, hostname, container, image, restart, latest):
+def update_image(ctx, cluster, service, hostname, container, image, restart, latest):
     ecs_client = ECSClient(timeout=ctx.obj['timeout'])
     service_arn = _get_service_arn(ecs_client, cluster, service)
 
@@ -90,7 +90,7 @@ def update_image(ctx, cluster, service, service_arn, hostname, container, image,
 @click.option("--service", required=False)
 @click.argument("taskdef_text", callback=_get_cli_stdin, required=False)
 @click.pass_context
-def update_taskdef(ctx, cluster, service, service_arn, taskdef_text):
+def update_taskdef(ctx, cluster, service, taskdef_text):
     ecs_client = ECSClient(timeout=ctx.obj['timeout'])
     service_arn = _get_service_arn(ecs_client, cluster, service)
 
@@ -137,7 +137,7 @@ def get_images(ctx, cluster, service, container):
               help="Directory name in $HOME where your ssh pem files are stored", default=".ssh")
 @click.option("--chamber-env", required=False)
 @click.pass_context
-def ssh_service(ctx, cluster, service, service_arn, task_arn, rails, user, keydir, chamber_env):
+def ssh_service(ctx, cluster, service, task_arn, rails, user, keydir, chamber_env):
     ecs_client = ECSClient(timeout=ctx.obj['timeout'])
 
     service_arn = _get_service_arn(ecs_client, cluster, service)

--- a/src/ecs_cluster/main.py
+++ b/src/ecs_cluster/main.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import json
 import sys
-import sys
 import click
 
 from .ecs_client import ECSClient

--- a/src/ecs_cluster/main.py
+++ b/src/ecs_cluster/main.py
@@ -17,7 +17,7 @@ def _get_service_arn(ecs_client, cluster, service):
             sys.exit(1)
         matches = [arn for arn in services
                    if service == arn.split('/', 1)[1]]
-        if len(matches) > 0:
+        if matches:
             service_arn = matches[0]
     return service_arn
 

--- a/src/ecs_cluster/main.py
+++ b/src/ecs_cluster/main.py
@@ -54,7 +54,6 @@ def list_services(ctx, cluster):
 @click.command('update-image', context_settings=dict(max_content_width=120))
 @click.option("--cluster", required=True)
 @click.option("--service", required=False)
-@click.option("--service-arn", required=False)
 @click.option("--hostname", required=False)
 @click.option("--container", required=True)
 @click.option("--image", required=True)


### PR DESCRIPTION
There was a bug introduced which was caused the wrong service to be used in most use cases, due to previous functionality if a service wasn't found we defaulted to returning the first service returned.

- Resolved matching bug
- Removed old behaviour of returning a random service when a search fails (to dangerous to keep around, there was already a casualty  (dvo-bot) ☠️ 
