### PR TITLE
adding --entrypoint parameter to be passed in to override the task definition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(fname):
 
 setup(
     name='ecs-cluster',
-    version='1.2.2',
+    version='1.3.0',
     author='Silvercar',
     author_email="info@silvercar.com",
     url='https://github.com/silvercar/ecs-cluster',

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -96,7 +96,7 @@ class ECSClient:
         return service
 
     def update_image(self, cluster_name, service_arn, container_name,
-                     hostname, image_name, latest=False, entrypoint=False):
+                     hostname, image_name, latest=False, entrypoint=None):
         """ Update the image in a task definition
 
             Same as redeploy_image, except the tasks won't be stopped. Instead,

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -96,7 +96,7 @@ class ECSClient:
         return service
 
     def update_image(self, cluster_name, service_arn, container_name,
-                     hostname, image_name, latest=False):
+                     hostname, image_name, latest=False, entrypoint=False):
         """ Update the image in a task definition
 
             Same as redeploy_image, except the tasks won't be stopped. Instead,
@@ -118,7 +118,8 @@ class ECSClient:
         new_taskdef_arn = self.clone_task(old_taskdef_arn,
                                           container_name,
                                           image_name,
-                                          hostname)
+                                          hostname,
+                                          entrypoint)
         if new_taskdef_arn is None:
             _print_error(
                 "Unable to clone the task definition " + old_taskdef_arn)
@@ -214,7 +215,8 @@ class ECSClient:
         return [{'container': x['name'], 'image': x['image']} for x in
                 response['taskDefinition']['containerDefinitions']]
 
-    def clone_task(self, task_definition_arn, container_name, image_name, hostname=None):
+    def clone_task(self, task_definition_arn, container_name, image_name,
+                   hostname=None, entrypoint=None):
         """ Clones a task and sets its image attribute. Returns the new
             task definition arn if successful, otherwise None
         """
@@ -233,6 +235,8 @@ class ECSClient:
                 container['image'] = image_name
                 if hostname is not None:
                     container['hostname'] = hostname
+                if entrypoint is not None:
+                    container['entryPoint'] = entrypoint
         task_def['containerDefinitions'] = containers
 
         # Remove fields not required for new task def

--- a/src/ecs_cluster/main.py
+++ b/src/ecs_cluster/main.py
@@ -55,6 +55,7 @@ def list_services(ctx, cluster):
 @click.option("--cluster", required=True)
 @click.option("--service", required=False)
 @click.option("--hostname", required=False)
+@click.option("--entrypoint", required=False)
 @click.option("--container", required=True)
 @click.option("--image", required=True)
 @click.option("--restart", is_flag=True, default=False,
@@ -62,7 +63,7 @@ def list_services(ctx, cluster):
 @click.option("--latest", is_flag=True, default=False,
               help="Update the latest task definition, even if it's not the one currently in use")
 @click.pass_context
-def update_image(ctx, cluster, service, hostname, container, image, restart, latest):
+def update_image(ctx, cluster, service, hostname, entrypoint, container, image, restart, latest):
     ecs_client = ECSClient(timeout=ctx.obj['timeout'])
     service_arn = _get_service_arn(ecs_client, cluster, service)
 
@@ -76,7 +77,7 @@ def update_image(ctx, cluster, service, hostname, container, image, restart, lat
             cluster, service_arn, container, image)
     else:
         service = ecs_client.update_image(
-            cluster, service_arn, container, hostname, image, latest)
+            cluster, service_arn, container, hostname, image, latest, entrypoint)
 
     if service:
         click.echo('Success')


### PR DESCRIPTION
* adding `--entrypoint` parameter to be passed in to override the task definition's `entrypoint`, if no value is provided it will not override current `entrypoint`
* this should allow us to not have to create a separate `onetime` task definition with a different `entrypoint`
