### PR TITLE
allowing to overwrite the command when updating the task

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(fname):
 
 setup(
     name='ecs-cluster',
-    version='1.3.1',
+    version='1.4.0',
     author='Silvercar',
     author_email="info@silvercar.com",
     url='https://github.com/silvercar/ecs-cluster',

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -96,7 +96,7 @@ class ECSClient:
         return service
 
     def update_image(self, cluster_name, service_arn, container_name,
-                     hostname, image_name, latest=False, entrypoint=None):
+                     hostname, image_name, latest=False, entrypoint=None, command=None):
         """ Update the image in a task definition
 
             Same as redeploy_image, except the tasks won't be stopped. Instead,
@@ -119,7 +119,8 @@ class ECSClient:
                                           container_name,
                                           image_name,
                                           hostname,
-                                          entrypoint)
+                                          entrypoint,
+                                          command)
         if new_taskdef_arn is None:
             _print_error(
                 "Unable to clone the task definition " + old_taskdef_arn)
@@ -216,7 +217,7 @@ class ECSClient:
                 response['taskDefinition']['containerDefinitions']]
 
     def clone_task(self, task_definition_arn, container_name, image_name,
-                   hostname=None, entrypoint=None):
+                   hostname=None, entrypoint=None, command=None):
         """ Clones a task and sets its image attribute. Returns the new
             task definition arn if successful, otherwise None
         """
@@ -237,6 +238,8 @@ class ECSClient:
                     container['hostname'] = hostname
                 if entrypoint is not None:
                     container['entryPoint'] = entrypoint.split()
+                if command is not None:
+                    container['command'] = command.split()
         task_def['containerDefinitions'] = containers
 
         # Remove fields not required for new task def

--- a/src/ecs_cluster/main.py
+++ b/src/ecs_cluster/main.py
@@ -55,6 +55,7 @@ def list_services(ctx, cluster):
 @click.option("--cluster", required=True)
 @click.option("--service", required=False)
 @click.option("--hostname", required=False)
+@click.option("--command", required=False)
 @click.option("--entrypoint", required=False)
 @click.option("--container", required=True)
 @click.option("--image", required=True)
@@ -63,7 +64,8 @@ def list_services(ctx, cluster):
 @click.option("--latest", is_flag=True, default=False,
               help="Update the latest task definition, even if it's not the one currently in use")
 @click.pass_context
-def update_image(ctx, cluster, service, hostname, entrypoint, container, image, restart, latest):
+def update_image(ctx, cluster, service, hostname, command, entrypoint,
+                 container, image, restart, latest):
     ecs_client = ECSClient(timeout=ctx.obj['timeout'])
     service_arn = _get_service_arn(ecs_client, cluster, service)
 
@@ -77,7 +79,7 @@ def update_image(ctx, cluster, service, hostname, entrypoint, container, image, 
             cluster, service_arn, container, image)
     else:
         service = ecs_client.update_image(
-            cluster, service_arn, container, hostname, image, latest, entrypoint)
+            cluster, service_arn, container, hostname, image, latest, entrypoint, command)
 
     if service:
         click.echo('Success')


### PR DESCRIPTION
allowing the option to override the `command` in the task definition, historically we use the `ecs-cluster` tool update the image through our CI/CD pipeline and we use AWS CLI `aws ecs run-task` to run "onetime" tasks

We can override the `command` using `aws ecs run-task` but not the entrypoint, ideally we just want to keep the same entrypoint and just override the `command` with this change