### PR TITLE
Changes ecs-cluster to only deregister task definitions that it has managed previously

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,6 +25,7 @@ jobs=1
 # object. This can help the performance when dealing with large functions or
 # complex, nested conditions.
 limit-inference-results=100
+max-line-length=120
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.

--- a/.pylintrc
+++ b/.pylintrc
@@ -25,7 +25,6 @@ jobs=1
 # object. This can help the performance when dealing with large functions or
 # complex, nested conditions.
 limit-inference-results=100
-max-line-length=120
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
@@ -233,7 +232,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -83,6 +83,8 @@ class ECSClient:
                 "Unable to clone the task definition " + old_taskdef_arn)
             return False
 
+        self.ecs_client.tag_resource(resourceArn=new_taskdef_arn, tags=[{'key': 'Managed', 'value', 'ecs-cluster'}])
+
         service = self.redeploy_service_task(cluster_name,
                                              service_arn,
                                              old_taskdef_arn,
@@ -97,7 +99,7 @@ class ECSClient:
             we'll let the ecs-agent do its thing and replace the tasks following
             whatever deployment strategy is configured.
         """
-        latest_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn)
+        latest_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn, search_tag='ecs-cluster')
 
         if latest_task_definition_arn is None:
             _print_error(
@@ -178,7 +180,7 @@ class ECSClient:
             return service['taskDefinition']
         return None
 
-    def get_latest_task_definition_arn(self, cluster_name, service_name):
+    def get_latest_task_definition_arn(self, cluster_name, service_name, search_tag=''):
 
         active_arn = self.get_task_definition_arn(cluster_name, service_name)
         family = self.get_task_family(active_arn)
@@ -189,13 +191,17 @@ class ECSClient:
             status='ACTIVE',
             sort='DESC'
         )
-        for task_definition_arn in response['taskDefinitionArns']:
-            tags = self.ecs_client.list_tags_for_resource(resourceArn=task_definition_arn).get('tags')
-            for tag in tags:
-                if tag['key'] == 'Managed' and tag['value'] == 'ecs-cluster':
-                    return task_definition_arn
-        print("Unable to find a task definition that is managed by ecs-cluster, returning 'None'")
-        return None
+        if not search_tag: 
+            latest_arn = response['taskDefinitionArns'][0]
+            return latest_arn
+        else:
+            for task_definition_arn in response['taskDefinitionArns']:
+                tags = self.ecs_client.list_tags_for_resource(resourceArn=task_definition_arn).get('tags')
+                for tag in tags:
+                    if tag['key'] == 'Managed' and tag['value'] == 'ecs-cluster':
+                        return task_definition_arn
+            print("Unable to find a task definition that is tagged 'Managed=%s', returning 'None'" % search_tag)
+            return None
 
     def register_task_definition(self, register_kwargs):
         response = self.ecs_client.register_task_definition(**register_kwargs)

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -83,7 +83,7 @@ class ECSClient:
                 "Unable to clone the task definition " + old_taskdef_arn)
             return False
 
-        self.ecs_client.tag_resource(resourceArn=new_taskdef_arn, tags=[{'key': 'Managed', 'value', 'ecs-cluster'}])
+        self.ecs_client.tag_resource(resourceArn=new_taskdef_arn, tags=[{'key': 'Managed', 'value': 'ecs-cluster'}])
 
         service = self.redeploy_service_task(cluster_name,
                                              service_arn,

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -99,7 +99,8 @@ class ECSClient:
             we'll let the ecs-agent do its thing and replace the tasks following
             whatever deployment strategy is configured.
         """
-        latest_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn, search_tag='ecs-cluster')
+        latest_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn,
+                                                                         search_tag='ecs-cluster')
 
         if latest_task_definition_arn is None:
             _print_error(

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -117,7 +117,7 @@ class ECSClient:
                 "Unable to clone the task definition " + latest_task_definition_arn)
             return False
         
-        self.ecs_client.tag_resource(resourceArn=new_taskdef_arn, tags=[{'key': 'Managed', 'value', 'ecs-cluster'}])
+        self.ecs_client.tag_resource(resourceArn=new_taskdef_arn, tags=[{'key': 'Managed', 'value': 'ecs-cluster'}])
 
         self.deregister_task_definition(latest_task_definition_arn)
 

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -116,7 +116,7 @@ class ECSClient:
             _print_error(
                 "Unable to clone the task definition " + latest_task_definition_arn)
             return False
-        
+
         self.ecs_client.tag_resource(resourceArn=new_taskdef_arn, tags=[{'key': 'Managed', 'value': 'ecs-cluster'}])
 
         self.deregister_task_definition(latest_task_definition_arn)
@@ -191,17 +191,17 @@ class ECSClient:
             status='ACTIVE',
             sort='DESC'
         )
-        if not search_tag: 
+        if not search_tag:
             latest_arn = response['taskDefinitionArns'][0]
             return latest_arn
-        else:
-            for task_definition_arn in response['taskDefinitionArns']:
-                tags = self.ecs_client.list_tags_for_resource(resourceArn=task_definition_arn).get('tags')
-                for tag in tags:
-                    if tag['key'] == 'Managed' and tag['value'] == 'ecs-cluster':
-                        return task_definition_arn
-            print("Unable to find a task definition that is tagged 'Managed=%s', returning 'None'" % search_tag)
-            return None
+
+        for task_definition_arn in response['taskDefinitionArns']:
+            tags = self.ecs_client.list_tags_for_resource(resourceArn=task_definition_arn).get('tags')
+            for tag in tags:
+                if tag['key'] == 'Managed' and tag['value'] == 'ecs-cluster':
+                    return task_definition_arn
+        print("Unable to find a task definition that is tagged 'Managed=%s', returning 'None'" % search_tag)
+        return None
 
     def register_task_definition(self, register_kwargs):
         response = self.ecs_client.register_task_definition(**register_kwargs)

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -114,6 +114,8 @@ class ECSClient:
             _print_error(
                 "Unable to clone the task definition " + latest_task_definition_arn)
             return False
+        
+        self.ecs_client.tag_resource(resourceArn=new_taskdef_arn, tags=[{'key': 'Managed', 'value', 'ecs-cluster'}])
 
         self.deregister_task_definition(latest_task_definition_arn)
 
@@ -187,9 +189,13 @@ class ECSClient:
             status='ACTIVE',
             sort='DESC'
         )
-
-        latest_arn = response['taskDefinitionArns'][0]
-        return latest_arn
+        for task_definition_arn in response['taskDefinitionArns']:
+            tags = self.ecs_client.list_tags_for_resource(resourceArn=task_definition_arn).get('tags')
+            for tag in tags:
+                if tag['key'] == 'Managed' and tag['value'] == 'ecs-cluster':
+                    return task_definition_arn
+        print("Unable to find a task definition that is managed by ecs-cluster, returning 'None'")
+        return None
 
     def register_task_definition(self, register_kwargs):
         response = self.ecs_client.register_task_definition(**register_kwargs)


### PR DESCRIPTION
Changes ecs-cluster to only deregister task definitions that it has managed previously.

- Changed latest_task_definition function to only return task definitions that are managed by ecs-cluster.
  - This task definition arn is used for deregistration
- Tags all task definitions created by update_image and redeploy_image with `Managed=ecs-cluster`