### PR TITLE
Always deregister the most recent task definition tagged ecs-cluster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(fname):
 
 setup(
     name='ecs-cluster',
-    version='1.6.0',
+    version='1.5.2',
     author='Silvercar',
     author_email="info@silvercar.com",
     url='https://github.com/silvercar/ecs-cluster',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(fname):
 
 setup(
     name='ecs-cluster',
-    version='1.5.1',
+    version='1.6.0',
     author='Silvercar',
     author_email="info@silvercar.com",
     url='https://github.com/silvercar/ecs-cluster',

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -120,8 +120,8 @@ class ECSClient:
             return False
 
         self.ecs_client.tag_resource(resourceArn=new_taskdef_arn, tags=[{'key': 'Managed', 'value': 'ecs-cluster'}])
-        if latest_ecs_task_definition_arn is not None:
-            self.deregister_task_definition(latest_ecs_task_definition_arn)
+        if latest_ecs_cluster_managed_task_definition_arn is not None:
+            self.deregister_task_definition(latest_ecs_cluster_managed_task_definition_arn)
 
         service = self.update_service(cluster_name, service_arn, new_taskdef_arn)
         if not service:

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -100,8 +100,8 @@ class ECSClient:
             whatever deployment strategy is configured.
         """
         latest_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn)
-        latest_ecs_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn,
-                                                                             search_tag='ecs-cluster')
+        latest_ecs_cluster_managed_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn,
+                                                                                             search_tag='ecs-cluster')
 
         if latest_task_definition_arn is None:
             _print_error(

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -120,7 +120,7 @@ class ECSClient:
             return False
 
         self.ecs_client.tag_resource(resourceArn=new_taskdef_arn, tags=[{'key': 'Managed', 'value': 'ecs-cluster'}])
-        if latest_ecs_task_definition_arn is None:
+        if latest_ecs_task_definition_arn is not None:
             self.deregister_task_definition(latest_ecs_task_definition_arn)
 
         service = self.update_service(cluster_name, service_arn, new_taskdef_arn)

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -99,7 +99,8 @@ class ECSClient:
             we'll let the ecs-agent do its thing and replace the tasks following
             whatever deployment strategy is configured.
         """
-        latest_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn,
+        latest_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn)
+        latest_ecs_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn,
                                                                          search_tag='ecs-cluster')
 
         if latest_task_definition_arn is None:
@@ -119,8 +120,8 @@ class ECSClient:
             return False
 
         self.ecs_client.tag_resource(resourceArn=new_taskdef_arn, tags=[{'key': 'Managed', 'value': 'ecs-cluster'}])
-
-        self.deregister_task_definition(latest_task_definition_arn)
+        if latest_ecs_task_definition_arn is None:
+            self.deregister_task_definition(latest_ecs_task_definition_arn)
 
         service = self.update_service(cluster_name, service_arn, new_taskdef_arn)
         if not service:
@@ -199,7 +200,7 @@ class ECSClient:
         for task_definition_arn in response['taskDefinitionArns']:
             tags = self.ecs_client.list_tags_for_resource(resourceArn=task_definition_arn).get('tags')
             for tag in tags:
-                if tag['key'] == 'Managed' and tag['value'] == 'ecs-cluster':
+                if tag['key'] == 'Managed' and tag['value'] == search_tag:
                     return task_definition_arn
         print("Unable to find a task definition that is tagged 'Managed=%s', returning 'None'" % search_tag)
         return None

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -101,7 +101,7 @@ class ECSClient:
         """
         latest_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn)
         latest_ecs_task_definition_arn = self.get_latest_task_definition_arn(cluster_name, service_arn,
-                                                                         search_tag='ecs-cluster')
+                                                                             search_tag='ecs-cluster')
 
         if latest_task_definition_arn is None:
             _print_error(


### PR DESCRIPTION
update_image:
- Now gets most recent task definition and the most recent task definition tagged 'ecs-cluster'.
- The most recent task definition is cloned to form the updated task def
- The latest task definition tagged 'ecs-cluster' is deregistered, if it exists

get_latest_task_definition_arn:
- fixed error where search_tag was hard-coded as 'ecs-cluster'