### PR TITLE
Increase the number of results in list_services

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(fname):
 
 setup(
     name='ecs-cluster',
-    version='1.5.2',
+    version='1.5.3',
     author='Silvercar',
     author_email="info@silvercar.com",
     url='https://github.com/silvercar/ecs-cluster',

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -325,9 +325,7 @@ class ECSClient:
 
     # pylint: disable=too-many-locals
     def docker_stats(self, cluster_name, ssh_keydir, user):
-        # pylint: disable=unnecessary-comprehension
-        arns = [x for x in self.ecs_client.list_container_instances(
-            cluster=cluster_name)["containerInstanceArns"]]
+        arns = self.ecs_client.list_container_instances(cluster=cluster_name)["containerInstanceArns"]
         host_ids = [x["ec2InstanceId"] for x in self.ecs_client.describe_container_instances(
             cluster=cluster_name, containerInstances=arns)["containerInstances"]]
         hosts = [self._get_ec2_details(x) for x in host_ids]

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -325,6 +325,7 @@ class ECSClient:
 
     # pylint: disable=too-many-locals
     def docker_stats(self, cluster_name, ssh_keydir, user):
+        # pylint: disable=unnecessary-comprehension
         arns = [x for x in self.ecs_client.list_container_instances(
             cluster=cluster_name)["containerInstanceArns"]]
         host_ids = [x["ec2InstanceId"] for x in self.ecs_client.describe_container_instances(

--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -135,7 +135,8 @@ class ECSClient:
         """ Returns the ARN of all services found for the cluster
         """
         try:
-            response = self.ecs_client.list_services(cluster=cluster_name)
+            response = self.ecs_client.list_services(cluster=cluster_name,
+                                                     maxResults=100)
         except ClientError:
             _print_error(
                 "Error getting list of services for %s" % cluster_name)


### PR DESCRIPTION
The default is 10 and some of our clusters have more than 10 services, causing some not to be found. 100 is the max allowed before adding paging support.