### PR TITLE
Support container-name param

### DIFF
--- a/src/ecs_cluster/ecs_client.py
+++ b/src/ecs_cluster/ecs_client.py
@@ -458,7 +458,7 @@ class ECSClient:
             return [container['DockerId']
                     for container in tasks[0]['Containers']
                     if container['Name'] == container_name][0]
-                    
+
         return [container['DockerId'] for container in tasks[0]['Containers']][0]
 
     def _get_ec2_details(self, ec2_arn):

--- a/src/ecs_cluster/main.py
+++ b/src/ecs_cluster/main.py
@@ -140,8 +140,9 @@ def get_images(ctx, cluster, service, container):
               help="Name of the PEM file in the keydir. If not specified, it "
                    "will use the key name as specified by the ECS cluster config")
 @click.option("--chamber-env", required=False)
+@click.option("--container-name", required=False, default=None)
 @click.pass_context
-def ssh_service(ctx, cluster, service, task_arn, rails, user, keydir, keyname, chamber_env):
+def ssh_service(ctx, cluster, service, task_arn, rails, user, keydir, keyname, chamber_env, container_name):
     ecs_client = ECSClient(timeout=ctx.obj['timeout'])
 
     service_arn = _get_service_arn(ecs_client, cluster, service)
@@ -157,7 +158,7 @@ def ssh_service(ctx, cluster, service, task_arn, rails, user, keydir, keyname, c
         service_cmd = 'chamber exec {} -- {}'.format(chamber_env, service_cmd)
 
     ecs_client.ssh_to_service(cluster, service_arn,
-                              task_arn, user, keydir, service_cmd, keyname)
+                              task_arn, user, keydir, service_cmd, keyname, container_name)
 
 
 @click.command('docker-stats')


### PR DESCRIPTION
Support passing --container-name to the ssh-service command, this is needed for cases where task definitions contain multiple containers
